### PR TITLE
Fix Extreme Packet Spam while pushing items into Crates.

### DIFF
--- a/src/main/java/assemblyline/common/tile/TileCrate.java
+++ b/src/main/java/assemblyline/common/tile/TileCrate.java
@@ -18,7 +18,8 @@ import net.minecraft.world.level.block.state.BlockState;
 public class TileCrate extends GenericTile {
 	private int lastCheckCount = 0;
 	private int count = 0;
-
+	private boolean updatingWithScheduler = false;
+	
 	public TileCrate(BlockPos worldPosition, BlockState blockState) {
 		this(64, worldPosition, blockState);
 	}
@@ -35,7 +36,12 @@ public class TileCrate extends GenericTile {
 		for (int i = 0; i < this.<ComponentInventory>getComponent(ComponentType.Inventory).getContainerSize(); i++) {
 			set.add(i);
 		}
-		Scheduler.schedule(1, () -> this.<ComponentPacketHandler>getComponent(ComponentType.PacketHandler).sendGuiPacketToTracking());
+		if (!updatingWithScheduler) {
+			Scheduler.schedule(1, () -> {
+				this.<ComponentPacketHandler>getComponent(ComponentType.PacketHandler).sendGuiPacketToTracking();
+				updatingWithScheduler = false;	
+				});
+		}
 		return set;
 	}
 

--- a/src/main/java/assemblyline/common/tile/TileCrate.java
+++ b/src/main/java/assemblyline/common/tile/TileCrate.java
@@ -37,6 +37,7 @@ public class TileCrate extends GenericTile {
 			set.add(i);
 		}
 		if (!updatingWithScheduler) {
+			updatingWithScheduler = true;
 			Scheduler.schedule(1, () -> {
 				this.<ComponentPacketHandler>getComponent(ComponentType.PacketHandler).sendGuiPacketToTracking();
 				updatingWithScheduler = false;	


### PR DESCRIPTION
Fixes the recent issue of high ping, and heavy TPS due to an obscene amount of packets being spammed.

This reduces the max number of packets a crate can send out to 1 per 2 ticks, as a cause of something requesting its Inventory Slots, (Conveyers, Hoppers And Auto-Ejector upgrade).