### PR TITLE
Prevent OutOfBoundsError by ensuring <=1.0

### DIFF
--- a/src/main/java/assemblyline/client/render/tile/RenderBlockBreaker.java
+++ b/src/main/java/assemblyline/client/render/tile/RenderBlockBreaker.java
@@ -69,7 +69,7 @@ public class RenderBlockBreaker extends AbstractTileRenderer<TileBlockBreaker> {
 
         PoseStack.Pose pose = matrixStackIn.last();
 
-        VertexConsumer vertexconsumer1 = new SheetedDecalTextureGenerator(Minecraft.getInstance().renderBuffers().crumblingBufferSource().getBuffer(ModelBakery.DESTROY_TYPES.get((int) (breaker.progress.get() * 9))), pose, 1.0F);
+        VertexConsumer vertexconsumer1 = new SheetedDecalTextureGenerator(Minecraft.getInstance().renderBuffers().crumblingBufferSource().getBuffer(ModelBakery.DESTROY_TYPES.get((int) (Math.min(breaker.progress.get(),1.0) * 9))), pose, 1.0F);
 
         matrixStackIn.translate(breaking.getStepX(), 0, breaking.getStepZ());
 


### PR DESCRIPTION
Fixing the possibility of getting an index OutOfBoundsError by clamping the progress of the BlockBreaker to <=1.0 when looking up the right destroy type
This fixes #50 